### PR TITLE
fix: correctly handle `proxyHeaders: false`

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -96,7 +96,8 @@ export default (ctx, inject) => {
   // Defaults
   const defaults = {
     retry: <%= parseInt(options.retry) %>,
-    prefixUrl
+    prefixUrl,
+    headers: {}
   }
 
   <% if (options.proxyHeaders) { %>
@@ -107,11 +108,8 @@ export default (ctx, inject) => {
 
   if (process.server) {
     // Don't accept brotli encoding because Node can't parse it
-    <% if (options.proxyHeaders) { %>
     defaults.headers['Accept-Encoding'] = 'gzip, deflate'
-    <% }else{ %>
-      defaults.headers = { 'Accept-Encoding': 'gzip, deflate' }
-    <%}%>
+
   }
 
   // Create new HTTP instance

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -109,7 +109,6 @@ export default (ctx, inject) => {
   if (process.server) {
     // Don't accept brotli encoding because Node can't parse it
     defaults.headers['Accept-Encoding'] = 'gzip, deflate'
-
   }
 
   // Create new HTTP instance

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -107,7 +107,11 @@ export default (ctx, inject) => {
 
   if (process.server) {
     // Don't accept brotli encoding because Node can't parse it
+    <% if (options.proxyHeaders) { %>
     defaults.headers['Accept-Encoding'] = 'gzip, deflate'
+    <% }else{ %>
+      defaults.headers = { 'Accept-Encoding': 'gzip, deflate' }
+    <%}%>
   }
 
   // Create new HTTP instance


### PR DESCRIPTION
When proxyHeaders is false trying to overwrite the object fails, added a conditional check on build to see if it exists or not.