### PR TITLE
fix: lowercase `accept-encoding` header

### DIFF
--- a/docs/api/readme.md
+++ b/docs/api/readme.md
@@ -126,7 +126,7 @@ When directing requests at a url protected by CloudFlare's CDN you should set th
 
 ### `proxyHeadersIgnore`
 
-* Default `['host', 'accept']`
+* Default `['accept', 'host', 'cf-ray', 'cf-connecting-ip']`
 
 Only efficient when `proxyHeaders` is set to true. Removes unwanted request headers to the API backend in SSR.
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -108,7 +108,7 @@ export default (ctx, inject) => {
 
   if (process.server) {
     // Don't accept brotli encoding because Node can't parse it
-    defaults.headers['Accept-Encoding'] = 'gzip, deflate'
+    defaults.headers['accept-encoding'] = 'gzip, deflate'
   }
 
   // Create new HTTP instance

--- a/test/fixture/pages/ssr.vue
+++ b/test/fixture/pages/ssr.vue
@@ -16,7 +16,7 @@ export default {
     },
 
     httpEncoding() {
-      return this.$http._defaults.headers['Accept-Encoding']
+      return this.$http._defaults.headers['accept-encoding']
     }
   },
   fetch({ app, route }) {


### PR DESCRIPTION
Actually, since `accept-encoding` is not in `proxyHeadersIgnore` and that we overwrite `Accept-Encoding`, it still fails on node.js when using Chrome (asking for `'gzip, deflate, br'`).

This fixes the issue.