### PR TITLE
feat: convert header names to lowercase

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,6 +2,9 @@ import KY from 'ky-universal'
 
 class HTTP {
   constructor(defaults, ky = KY) {
+    const headers = defaults.headers
+    delete defaults.headers
+
     this._defaults = {
       hooks: {},
       headers: {},
@@ -9,6 +12,10 @@ class HTTP {
       ...defaults
     }
     this._ky = ky
+
+    for (const name in headers) {
+      this.setHeader(name, headers[name])
+    }
   }
 
   setHeader(name, value) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -12,6 +12,8 @@ class HTTP {
   }
 
   setHeader(name, value) {
+    name = name.toLowerCase()
+
     if (!value) {
       delete this._defaults.headers[name];
     } else {

--- a/test/fixture/pages/ssr.vue
+++ b/test/fixture/pages/ssr.vue
@@ -12,7 +12,7 @@ let reqCtr = 1
 export default {
   computed: {
     httpSessionId() {
-      return this.$http._defaults.headers.sessionId
+      return this.$http._defaults.headers.sessionid
     },
 
     httpEncoding() {


### PR DESCRIPTION
Ky converts all header names to lower-case. This pr forces headers set by the plugin to have lower-case names as well so we dont pass two headers with different casing to Ky/fetch.Headers (which then might decide for itself which one to use).