### PR TITLE
fix(types): fix argument of onError

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -138,7 +138,7 @@ interface NuxtHTTPInstance {
    *
    * This hook enables you to globally handle request errors.
    */
-  onError(hook: (HTTPError) => void): void
+  onError(hook: (error: HTTPError) => void): void
 }
 
 declare module '@nuxt/vue-app' {


### PR DESCRIPTION
On Nuxt TypeScript project using http module, we have a type error from tslint

```
 ERROR  ERROR in /.../node_modules/@nuxt/http/types/index.d.ts(141,18):
141:18 Parameter has a name but no type. Did you mean 'arg0: HTTPError'?
    139 |    * This hook enables you to globally handle request errors.
    140 |    */
  > 141 |   onError(hook: (HTTPError) => void): void
        |                  ^
    142 | }
    143 | 
    144 | declare module '@nuxt/vue-app' {
```

This fix handle simply this typing issue.