### PR TITLE
fix: don't default to localhost in production

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -22,10 +22,11 @@ function httpModule (_moduleOptions) {
     moduleOptions.host ||
     process.env.HOST ||
     process.env.npm_package_config_nuxt_host ||
-    'localhost'
+    (this.options.dev ? 'localhost' : '0.0.0.0')
 
+  
   /* istanbul ignore if */
-  if (defaultHost === '0.0.0.0' && !this.options.dev) {
+  if (this.options.dev && defaultHost === '0.0.0.0') {
     defaultHost = 'localhost'
   }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -24,7 +24,6 @@ function httpModule (_moduleOptions) {
     process.env.npm_package_config_nuxt_host ||
     (this.options.dev ? 'localhost' : '0.0.0.0')
 
-  
   /* istanbul ignore if */
   if (this.options.dev && defaultHost === '0.0.0.0') {
     defaultHost = 'localhost'

--- a/lib/module.js
+++ b/lib/module.js
@@ -25,7 +25,7 @@ function httpModule (_moduleOptions) {
     'localhost'
 
   /* istanbul ignore if */
-  if (defaultHost === '0.0.0.0') {
+  if (defaultHost === '0.0.0.0' && !this.options.dev) {
     defaultHost = 'localhost'
   }
 


### PR DESCRIPTION
Noticed a live deployment with @nuxt/http was using `localhost` if no environment variable was set.