### PR TITLE
feat(types): provide nuxt 2.9 compatible types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -147,6 +147,13 @@ declare module '@nuxt/vue-app' {
   }
 }
 
+// Nuxt 2.9+
+declare module '@nuxt/types' {
+  interface Context {
+    $http: NuxtHTTPInstance
+  }
+}
+
 declare module 'vue/types/vue' {
   interface Vue {
     $http: NuxtHTTPInstance


### PR DESCRIPTION
Since Nuxt 2.9, types are defined around @nuxt/types packages.
These changes make the module types work with Nuxt 2.9 new TypeScript specs.

Reference URL:
https://github.com/nuxt-community/axios-module/pull/277