### PR TITLE
feat: enable advanced retry option

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -68,6 +68,10 @@ function httpModule (_moduleOptions) {
     options.retry = 2
   } else if (!options.retry) {
     options.retry = 0
+  } else if (!isNaN(options.retry)) {
+    options.retry = parseInt(options.retry)
+  } else if (typeof options.retry === 'object') {
+    options.retry = JSON.stringify(options.retry)
   }
 
   // Convert http:// to https:// if https option is on

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -98,7 +98,7 @@ export default (ctx, inject) => {
 
   // Defaults
   const defaults = {
-    retry: <%= parseInt(options.retry) %>,
+    retry: <%= options.retry %>,
     timeout: process.server ? <%= options.serverTimeout %> : <%= options.clientTimeout %>,
     prefixUrl,
     headers: {}


### PR DESCRIPTION
(sorry for my poor english)

for example:
API will returns 401 Unauthorized when token expires
https://www.rfc-editor.org/rfc/rfc6750#section-3

but ky does not retry 401 by default
https://github.com/sindresorhus/ky/blob/c5821a7fbf1af21f934ee5ed5a76fb224559c530/index.js#L119-L127

will be able to advanced specification like:
https://github.com/sindresorhus/ky/blob/c5821a7fbf1af21f934ee5ed5a76fb224559c530/index.js#L175-L180

nuxt.config.js
```
export default {
  ...
  http: {
    retry: {
      limit: 2,
      statusCodes: [401], 
    }
  }
  ...
}
```