### PR TITLE
fix: use json serialization for plain array

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -58,7 +58,7 @@ for (let method of ['get', 'head', 'delete', 'post', 'put', 'patch']) {
     } else {
       options = arg2 || {}
       if (arg1 !== undefined) {
-        if (arg1.constructor === Object) {
+        if (arg1.constructor === Object || Array.isArray(arg1)) {
           options.json = arg1
         } else {
           options.body = arg1


### PR DESCRIPTION
Currently, sending array of object is not a json.
It is sent as string in the body.(text/plain)

```javascript
$http.$post('api', [data1, data2]) // invalid "[object Object],[object Object]" text-plain
$http.$post('api', void 0, { json: [data1, data2] }) // OK application/json
```

This pull request makes it possible.

Thak you.