### PR TITLE
fix(types): update types for `HTTPError` to `ky.HTTPError`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { ResponsePromise, Options, BeforeRequestHook, BeforeRetryHook, AfterResponseHook, HTTPError } from 'ky'
+import ky, { ResponsePromise, Options, BeforeRequestHook, BeforeRetryHook, AfterResponseHook } from 'ky'
 import './vuex'
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
@@ -145,7 +145,7 @@ interface NuxtHTTPInstance {
    *
    * This hook enables you to globally handle request errors.
    */
-  onError(hook: (error: HTTPError) => void): void
+  onError(hook: (error: ky.HTTPError) => void): void
 }
 
 declare module '@nuxt/vue-app' {


### PR DESCRIPTION
Since [ky@0.19.0](https://github.com/sindresorhus/ky/releases/tag/v0.19.0), `HTTPError` is moved to namespaced `ky.HTTPError`, causing type errors in nuxt-ts.

Refer to this PR: https://github.com/sindresorhus/ky/pull/241