### PR TITLE
fix: remove leading slash when using prefixUrl

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -82,7 +82,8 @@ for (let method of ['get', 'head', 'delete', 'post', 'put', 'patch']) {
 
     if (/^https?/.test(url)) {
       delete _options.prefixUrl
-    } else if (_options.prefixUrl && url.startsWith('/')) {
+    } else if (_options.prefixUrl && typeof url === 'string' && url.startsWith('/')) {
+      // Prevents `ky` from throwing "`input` must not begin with a slash when using `prefixUrl`"
       url = url.substr(1)
     } 
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -82,7 +82,9 @@ for (let method of ['get', 'head', 'delete', 'post', 'put', 'patch']) {
 
     if (/^https?/.test(url)) {
       delete _options.prefixUrl
-    }
+    } else if (_options.prefixUrl && url.startsWith('/')) {
+      url = url.substr(1)
+    } 
 
     try {
       const response = await this._ky[method](url, _options)


### PR DESCRIPTION
This fix prevents the following error :

![image](https://user-images.githubusercontent.com/25272043/80587511-f99dbf80-8a16-11ea-9ef0-8457e98074b4.png)

by gently removing extra leading slash when using `prefixUrl`.

See : https://github.com/sindresorhus/ky/blob/master/index.js#L226