### PR TITLE
fix: debug option

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -131,7 +131,7 @@ const createHttpInstance = options => {
   const http = new HTTP(options)
 
   // Setup interceptors
-  <% if (options.debug) { %>setupDebugInterceptor(axios) <% } %>
+  <% if (options.debug) { %>setupDebugInterceptor(http) <% } %>
 
   return http
 }


### PR DESCRIPTION
When using the `http.debug` option at the moment, an error is thrown because the plugin is still using `axios` and not `http` as variable. This wasn't caught due to the nature of lodash templates.

<img width="1740" alt="image" src="https://user-images.githubusercontent.com/640208/87701881-e50cd000-c798-11ea-8ed7-b1ecedafdee2.png">

Maybe we should add Pim's lodash template linter here as well (if possible)?
