### PR TITLE
fix(ky-universal): server importing es bundle

### DIFF
--- a/ky-universal/node.js
+++ b/ky-universal/node.js
@@ -4,9 +4,7 @@ const AbortController = require('abort-controller')
 const TEN_MEGABYTES = 1000 * 1000 * 10
 
 if (!global.fetch) {
-  global.fetch = (url, options) => {
-  	return fetch(url, { highWaterMark: TEN_MEGABYTES, ...options })
-  }
+  global.fetch = (url, options) => fetch(url, { highWaterMark: TEN_MEGABYTES, ...options })
 }
 
 if (!global.Headers) {

--- a/ky-universal/node.js
+++ b/ky-universal/node.js
@@ -4,7 +4,11 @@ const AbortController = require('abort-controller')
 const TEN_MEGABYTES = 1000 * 1000 * 10
 
 if (!global.fetch) {
-  global.fetch = (url, options) => fetch(url, { highWaterMark: TEN_MEGABYTES, ...options })
+  global.fetch = (url, options) => {
+  	console.log(1);
+  	console.log(fetch);
+  	return fetch(url, { highWaterMark: TEN_MEGABYTES, ...options })
+  }
 }
 
 if (!global.Headers) {

--- a/ky-universal/node.js
+++ b/ky-universal/node.js
@@ -1,4 +1,5 @@
-const fetch = require('node-fetch/lib/index.js')
+const fetch = process.server ? require('node-fetch/lib/index.js') : require('node-fetch/browser.js')
+
 const AbortController = require('abort-controller')
 
 const TEN_MEGABYTES = 1000 * 1000 * 10

--- a/ky-universal/node.js
+++ b/ky-universal/node.js
@@ -1,6 +1,4 @@
-const _interopDefault = (ex) => ex && (typeof ex === 'object') && ('default' in ex) ? ex.default : ex
-
-const fetch = _interopDefault(require('node-fetch'))
+const fetch = require('node-fetch/lib/index.js')
 const AbortController = require('abort-controller')
 
 const TEN_MEGABYTES = 1000 * 1000 * 10

--- a/ky-universal/node.js
+++ b/ky-universal/node.js
@@ -1,4 +1,6 @@
-const fetch = require('node-fetch/lib/index.js')
+const _interopDefault = (ex) => ex && (typeof ex === 'object') && ('default' in ex) ? ex.default : ex
+
+const fetch = _interopDefault(require('node-fetch'))
 const AbortController = require('abort-controller')
 
 const TEN_MEGABYTES = 1000 * 1000 * 10

--- a/ky-universal/node.js
+++ b/ky-universal/node.js
@@ -5,8 +5,6 @@ const TEN_MEGABYTES = 1000 * 1000 * 10
 
 if (!global.fetch) {
   global.fetch = (url, options) => {
-  	console.log("require.resolve('node-fetch')", require.resolve('node-fetch'));
-  	console.log(fetch);
   	return fetch(url, { highWaterMark: TEN_MEGABYTES, ...options })
   }
 }

--- a/ky-universal/node.js
+++ b/ky-universal/node.js
@@ -1,11 +1,11 @@
-const fetch = require('node-fetch')
+const fetch = require('node-fetch/lib/index.js')
 const AbortController = require('abort-controller')
 
 const TEN_MEGABYTES = 1000 * 1000 * 10
 
 if (!global.fetch) {
   global.fetch = (url, options) => {
-  	console.log(1);
+  	console.log("require.resolve('node-fetch')", require.resolve('node-fetch'));
   	console.log(fetch);
   	return fetch(url, { highWaterMark: TEN_MEGABYTES, ...options })
   }


### PR DESCRIPTION
Using `@nuxt/http` on Vercel via `@nuxtjs/now-builder` and was getting the following error on the server-side:

<img width="985" alt="Screen Shot 2020-08-20 at 1 13 45 AM" src="https://user-images.githubusercontent.com/1075694/90719445-6d8ffc00-e282-11ea-8cbb-55c62e17acd1.png">

I added a `console.log(fetch);` (as you can see above) and it was importing the ESM version (`node-fetch/lib/index.es.js`). I specified the specific CJS build explicitly.