### PR TITLE
fix: use regex to avoid falsely replacing ports starting with 80

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -115,7 +115,7 @@ function httpModule (_moduleOptions) {
   }
 
   // Remove port 80 when http
-  if (/^http:\/\/.*:80$/.test(options.baseURL)) {
+  if (/^http:\/\/.*:80\/?$/.test(options.baseURL)) {
     options.baseURL = options.baseURL.replace(':80', '')
   }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -115,7 +115,7 @@ function httpModule (_moduleOptions) {
   }
 
   // Remove port 80 when http
-  if (/^http:\/\/.*:80\/?$/.test(options.baseURL)) {
+  if (/^http:\/\/.*:80(\/|$)/.test(options.baseURL)) {
     options.baseURL = options.baseURL.replace(':80', '')
   }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -115,7 +115,7 @@ function httpModule (_moduleOptions) {
   }
 
   // Remove port 80 when http
-  if (options.baseURL.includes('http://')) {
+  if (/^http:\/\/.*:80$/.test(options.baseURL)) {
     options.baseURL = options.baseURL.replace(':80', '')
   }
 


### PR DESCRIPTION
This PR fixes #120.

## Problem Statement

Following what the issue addresses, the following logic is currently used to remove `:80` when the baseURL starts with `http://`.

https://github.com/nuxt/http/blob/c002aaa97c45fa5dfd91325a005fd5cc18a55b57/lib/module.js#L117-L120

However, this logic will also be true for ANY ports that starts with `:80`, such as `:8081`, `:8000` and so on since they do technically contain `:80` in them.

## PR Fix

We can use the regex `/^http:\/\/.*:80$/` to make the check stricter, which requires the baseURL to fulfill all the following conditions:
- **Starts with `http://`** (`^http:\/\/` : `^` means "start of line" and we need to escape `/` into `\/`)
- contains whatever characters in between (`.*`: `.` means any character and `*` means appearing zero or more times)
- **Ends with `:80` only** (`:80$`: `$` means "end of line")

## Test Results

### Test Case 1 - baseURL ends with :80

![chrome_BpMxhForHB](https://user-images.githubusercontent.com/42867097/91480252-49ad6580-e8d5-11ea-806d-2f6b570ed6a7.png)

Both logic works as intended.

### Test Case 2 - baseURL ends with :8081

![chrome_A6KRw1HBEe](https://user-images.githubusercontent.com/42867097/91480291-5762eb00-e8d5-11ea-977d-8c0df15edc11.png)

Here we can see the original logic falsely turns `http://localhost:8081` to `http://localhost81` (as reported by the issue) whereas the regex logic will not trigger as intended.