### PR TITLE
docs: fix wrong URL for migration guide

### DIFF
--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -17,7 +17,7 @@ features:
 
 HTTP module for Nuxt.js provides a universal way to make HTTP requests to the API backend.
 
-This module is an alternative to [Axios Module](https://github.com/nuxt-community/axios-module). Behind the scenes it use [ky-universal](https://github.com/sindresorhus/ky-universal) and [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make HTTP requests. Please see the [migration guide](./guide/migration) if you are currently using axios module and wish to migrate.
+This module is an alternative to [Axios Module](https://github.com/nuxt-community/axios-module). Behind the scenes it use [ky-universal](https://github.com/sindresorhus/ky-universal) and [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make HTTP requests. Please see the [migration guide](./migration) if you are currently using axios module and wish to migrate.
 
 Starting from [v2.5.0](https://github.com/nuxt/nuxt.js/releases/tag/v2.5.0), Nuxt.js has built-in support for universal fetch. However, this module provides several advantages:
 


### PR DESCRIPTION
Apparently the current URL points to a wrong URL. This should be the right one based on the sidebar link