### PR TITLE
feat: `$http.getBaseURL`

### DIFF
--- a/docs/content/en/helpers.md
+++ b/docs/content/en/helpers.md
@@ -15,7 +15,7 @@ Helpers available on `$http` instance.
 
 - arguments: `(baseURL)`
 
-Globally set a header to all subsequent requests
+Globally set a base URL to all subsequent requests
 
 ```js
 // Set baseURL (both client and server)
@@ -30,6 +30,15 @@ if (process.client) {
 if (process.server) {
   this.$http.setBaseURL('http://api.example.com')
 }
+```
+
+## `getBaseURL`
+
+Get the value of the base URL
+
+```js
+// Get baseURL value
+this.$http.getBaseURL()
 ```
 
 ## `setHeader`

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -13,6 +13,10 @@ class HTTP {
     this._ky = ky
   }
 
+  getBaseURL (baseURL) {
+    return this._defaults.prefixUrl
+  }
+  
   setBaseURL (baseURL) {
     this._defaults.prefixUrl = baseURL
   }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -13,7 +13,7 @@ class HTTP {
     this._ky = ky
   }
 
-  getBaseURL (baseURL) {
+  getBaseURL () {
     return this._defaults.prefixUrl
   }
   

--- a/test/fixture/pages/instance.vue
+++ b/test/fixture/pages/instance.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <div>prefixUrl:{{ defaults.prefixUrl }}</div>
+    <div>baseURL:{{ baseURL }}</div>
     <div v-for="(value, key) in defaults.headers" :key="key">
       {{ key }}:{{ value }}
     </div>
@@ -11,6 +12,7 @@
 export default {
   asyncData ({ app: { $api } }) {
     return {
+      baseURL: $api.getBaseURL(),
       defaults: $api._defaults
     }
   }

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -80,6 +80,7 @@ describe('module', () => {
     const html = await fetch(url('/instance')).then(r => r.text())
 
     expect(html).toContain('prefixUrl:https://jsonplaceholder.typicode.com/')
+    expect(html).toContain('baseURL:https://jsonplaceholder.typicode.com/')
     expect(html).toContain('testing:oui')
   })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -105,6 +105,12 @@ interface NuxtHTTPInstance {
 
 
   /**
+   * Get the baseURL value.
+   * @returns string - the base URL value
+   */
+  getBaseURL(): string
+
+  /**
    * Set the baseURL for all subsequent requests.
    * @param baseURL - the base URL (e.g. `https://myapi.com/`)
    */


### PR DESCRIPTION
following #164 

This PR aims to create a getter for the internal prefixUrl property. This can be useful for computed properties in Vue templates. The `_defaults` property is not really resolving the issue since it has no type signature. This patch suggests a dedicated getter should be added.