### PR TITLE
Add FormData example to usage docs

### DIFF
--- a/docs/content/en/3.usage.md
+++ b/docs/content/en/3.usage.md
@@ -71,6 +71,14 @@ reader.read().then(function process ({ done, value }) {
 const data = await $http.$post('http://api.com', { foo: 'bar' })
 ```
 
+**Example: POST with FormData**
+
+```js
+const formData = new FormData()
+formData.append('foo', 'bar')
+const data = await $http.$post('http://api.com', formData)
+```
+
 ## Using in `asyncData`
 
 For `asyncData` and `fetch` you can access instance from context:


### PR DESCRIPTION
Since FormData requests work different than documented on https://github.com/sindresorhus/ky#sending-form-data this should be noted in the docs.