### PR TITLE
Fixed link to migration guide

### DIFF
--- a/docs/pages/en/1.index.md
+++ b/docs/pages/en/1.index.md
@@ -9,7 +9,7 @@ description: 'HTTP module for Nuxt.js provides a universal way to make HTTP requ
 
 The HTTP module for [Nuxt](https://nuxtjs.org) provides a universal way to make HTTP requests to any API.
 
-It uses [ky-universal](https://github.com/sindresorhus/ky-universal) and [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make HTTP requests. Please see the [migration guide](./migration) if you are currently using axios module and wish to migrate.
+It uses [ky-universal](https://github.com/sindresorhus/ky-universal) and [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make HTTP requests. Please see the [migration guide](./migration-guides/migration/) if you are currently using axios module and wish to migrate.
 
 Starting from [v2.5.0](https://github.com/nuxt/nuxt.js/releases/tag/v2.5.0), Nuxt.js has built-in support for universal fetch. However, this module provides several advantages.
 


### PR DESCRIPTION
This request propose changing the link from ./migration, to ./migration-guides/migration/ page, as previous link was broken