### PR TITLE
docs: add note about nuxt 3 compatibility 

### DIFF
--- a/docs/pages/en/1.index.md
+++ b/docs/pages/en/1.index.md
@@ -4,7 +4,7 @@ description: 'HTTP module for Nuxt.js provides a universal way to make HTTP requ
 ---
 
 :::alert{type="warning"}
-Nuxt 3 users can use the new [$fetch](https://v3.nuxtjs.org/docs/usage/data-fetching/#usefetch) method integrated in the framework.
+HTTP module supports Nuxt 2. Nuxt 3 users can use the new isomorphic [$fetch API](https://v3.nuxtjs.org/docs/usage/data-fetching/#usefetch) ([migration guide](https://v3.nuxtjs.org/docs/migration/component-options#isomorphic-fetch)).
 :::
 
 

--- a/docs/pages/en/1.index.md
+++ b/docs/pages/en/1.index.md
@@ -3,6 +3,11 @@ title: Introduction
 description: 'HTTP module for Nuxt.js provides a universal way to make HTTP requests to the API backend.'
 ---
 
+:::alert{type="warning"}
+This module will not be compatible with Nuxt 3 in the future, due to the [`$fetch`](https://v3.nuxtjs.org/docs/usage/data-fetching/#usefetch) method integrated in Nuxt 3.
+:::
+
+
 <img src="/preview.png" class="transition-shadow duration-200 rounded-md shadow light-img hover:shadow-lg" />
 
 <img src="/preview-dark.png" class="transition-shadow duration-200 rounded-md shadow dark-img hover:shadow-lg" />

--- a/docs/pages/en/1.index.md
+++ b/docs/pages/en/1.index.md
@@ -4,7 +4,7 @@ description: 'HTTP module for Nuxt.js provides a universal way to make HTTP requ
 ---
 
 :::alert{type="warning"}
-This module will not be compatible with Nuxt 3 in the future, due to the [`$fetch`](https://v3.nuxtjs.org/docs/usage/data-fetching/#usefetch) method integrated in Nuxt 3.
+Nuxt 3 users can use the new [$fetch](https://v3.nuxtjs.org/docs/usage/data-fetching/#usefetch) method integrated in the framework.
 :::
 
 


### PR DESCRIPTION
This module will not be compatible with Nuxt 3 in the future, due to the [`$fetch`](https://v3.nuxtjs.org/docs/usage/data-fetching/#usefetch) method integrated in Nuxt 3.

@Atinux 